### PR TITLE
Fix Course Listing Sizes

### DIFF
--- a/src/client/src/components/molecules/course/CourseListing.module.css
+++ b/src/client/src/components/molecules/course/CourseListing.module.css
@@ -1,5 +1,7 @@
 .courseCard {
     transition: transform 0.4s;
+    width: 20em !important;
+    height: 20em !important;
 }
 
 .courseCard:hover {

--- a/src/client/src/components/molecules/course/CourseListing.tsx
+++ b/src/client/src/components/molecules/course/CourseListing.tsx
@@ -54,8 +54,6 @@ export const CourseListing = ({
                 withBorder
                 className={classes.courseCard}
                 pos="relative"
-                w="18vw"
-                h="20vh"
                 bg={`url(${cover_image_url}) center / cover`}
                 onClick={onClick}
             >


### PR DESCRIPTION
This PR applies a small change that sets the course listing component to a static 20em square size, rather than going off of the viewport.