### PR TITLE
Playground Local Testing Setup

### DIFF
--- a/src/backend/app/services/playground_service.py
+++ b/src/backend/app/services/playground_service.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 from fastapi import Depends
-from config import get_playground_token_secret
+from config import get_playground_token_secret, get_playground_session_id_override
 from app.utilities.jwt import create_token
 from app.repositories import PlaygroundRepository
 
@@ -24,7 +24,8 @@ class PlaygroundService:
         Returns:
             Tuple[str, str]: The session ID and token for authorization
         """
-        session_id = await self.playground_repo.create_playground_session("basic")
+        session_override = get_playground_session_id_override()
+        session_id = await self.playground_repo.create_playground_session("basic") if session_override is None else session_override
         
         signing_key = get_playground_token_secret()
         token = create_token(

--- a/src/backend/app/websocket/websocket_server.py
+++ b/src/backend/app/websocket/websocket_server.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 from socketio import AsyncServer
 from app.utilities.jwt import decode_token, InvalidJWTToken
-from common.cache import set_key, get_key
+from common.cache import set_key, get_key, delete_key
 from config import get_playground_token_secret
 
 logging.basicConfig(level=logging.INFO)
@@ -89,10 +89,16 @@ async def disconnect(sid: str):
         if user_id is not None:
             logger.info(f"User {user_id} disconnected")
             await socket_server.emit("user_disconnected", room=session_id) # Notify the instance
+            
+            # delete the user connected key
+            delete_key(get_user_connected_cache_key(session_id))
         
         if instance_hostname is not None and session_id is not None:
             logger.info(f"Instance {instance_hostname} disconnected")
             await socket_server.emit("instance_disconnected", room=session_id) # Notify the user
+            
+            # delete the liveness key
+            delete_key(get_liveness_cache_key(session_id))
 
 @socket_server.event
 async def terminal_input(sid: str, t_input: str):

--- a/src/backend/common/cache.py
+++ b/src/backend/common/cache.py
@@ -37,6 +37,18 @@ def set_key(
         client.setex(key, expiration_delta, value)
     else:
         client.set(key, value)
+        
+def delete_key(key: str):
+    """
+    Deletes a key from the Redis cache
+
+    Args:
+        key (str): The key to delete
+    """
+    
+    client = _get_client()
+    
+    client.delete(key)
     
 def get_key(key: str) -> Optional[str]:
     """

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -52,8 +52,12 @@ def get_refresh_token_expiration_days() -> int:
 def get_token_secret() -> str:
     return os.getenv("TOKEN_SECRET", "secret")
 
+# Playground
 def get_playground_token_secret() -> str:
     return os.getenv("PLAYGROUND_TOKEN_SECRET", "secret")
+
+def get_playground_session_id_override() -> Optional[str]:
+    return os.getenv("OVERRIDE_PLAYGROUND_SESSION_ID", None)
 
 # S3 / Min.io
 def get_s3_endpoint() -> str:

--- a/src/backend/docker-compose.yml
+++ b/src/backend/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - REDIS_HOST=redis
       - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
       - REQUIRE_EMAIL_VALIDATION=false
+      - PLAYGROUND_TOKEN_SECRET=devkey123
+      - OVERRIDE_PLAYGROUND_SESSION_ID=fakeplaygroundsessionid
     depends_on:
       - database
       - redis
@@ -40,6 +42,38 @@ services:
       - database
     networks:
       - app-tier
+
+  playground-controller:
+    build:
+      context: ../playground
+      dockerfile: Dockerfile
+    environment:
+      - HOSTNAME=playground-controller
+      - BACKEND_SOCKETIO_ENDPOINT=http://api:8000
+      - JWT_SIGNING_KEY=devkey123
+      - SESSION_ID=fakeplaygroundsessionid
+      - PURGE_DATA_ON_DISCONNECT=true
+      - ENABLE_SELF_DESTRUCT=false
+    depends_on:
+      - api
+    networks:
+      - app-tier
+    volumes:
+      - playground_shared:/userland
+      - playground_hidden:/playground
+
+  playground-environment:
+    build:
+      context: ../playground
+      dockerfile: environment.Dockerfile
+    depends_on:
+      - api
+      - playground-controller
+    networks:
+      - app-tier
+    volumes:
+      - playground_shared:/userland
+      - playground_hidden:/playground
 
   redis:
     image: redis:6
@@ -111,3 +145,5 @@ networks:
 volumes:
   postgres_data:
   s3_data:
+  playground_hidden:
+  playground_shared:

--- a/src/backend/tests/app/services/test_playground_service.py
+++ b/src/backend/tests/app/services/test_playground_service.py
@@ -43,3 +43,39 @@ async def test_create_playground(mock_get_playground_token_secret, mock_create_t
     )
     
     assert result == (session_id, token)
+
+@pytest.mark.asyncio
+@patch("app.services.playground_service.create_token", autospec=True)
+@patch("app.services.playground_service.get_playground_token_secret", autospec=True)
+@patch("app.services.playground_service.get_playground_session_id_override", autospec=True)
+async def test_create_playground_session_override(mock_session_id_override, mock_get_playground_token_secret, mock_create_token, playground_service):
+    """
+    Test create_playground method when session ID override is set:
+    1. Should not create a new record in the repository.
+    2. Should generate a JWT token with the session ID and user ID.
+    3. Should return the session ID and token. Session ID should be the overridden value.
+    """
+    # Mock repository method
+    playground_service.playground_repo.create_playground_session = AsyncMock(return_value="incorrect_session_id")
+    
+    # Mock the external function to get the token secret
+    mock_get_playground_token_secret.return_value = "mocked_secret"
+    
+    # Mock the override
+    mock_session_id_override.return_value = session_id
+    
+    # Mock JWT token creation
+    mock_create_token.return_value = token
+    
+    result = await playground_service.create_playground(user_id=user_id)
+    
+    # Assertions
+    playground_service.playground_repo.create_playground_session.assert_not_called()
+    mock_get_playground_token_secret.assert_called_once()
+    mock_create_token.assert_called_once_with(
+        data={"session_id": session_id, "user_id": user_id},
+        secret="mocked_secret",
+        expiration_minutes=5
+    )
+    
+    assert result == (session_id, token)

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -73,7 +73,11 @@ const router = createBrowserRouter([
     },
     {
         path: "/playground-test",
-        element: <PlaygroundTest />,
+        element: (
+            <AuthorizedRoute>
+                <PlaygroundTest />
+            </AuthorizedRoute>
+        ),
     },
 ]);
 

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -10,6 +10,7 @@ import "./App.css";
 import "@mantine/core/styles.css";
 import "@mantine/dates/styles.css";
 import "@mantine/notifications/styles.css";
+import { PlaygroundTest } from "@views/playground-test";
 
 const AuthorizedRoute = ({ children }: { children: React.ReactNode }) => {
     const isAuthenticated = useAuthenticated();
@@ -69,6 +70,10 @@ const router = createBrowserRouter([
                 ],
             },
         ],
+    },
+    {
+        path: "/playground-test",
+        element: <PlaygroundTest />,
     },
 ]);
 

--- a/src/client/src/views/index.ts
+++ b/src/client/src/views/index.ts
@@ -5,3 +5,4 @@ export * from "./courses";
 export * from "./home";
 export * from "./router";
 export * from "./course";
+export * from "./playground-test";

--- a/src/client/src/views/playground-test/PlaygroundTest.tsx
+++ b/src/client/src/views/playground-test/PlaygroundTest.tsx
@@ -1,0 +1,10 @@
+import { PlaygroundProvider } from "@context/playground";
+import { Playground } from "@organisms";
+
+export const PlaygroundTest = () => {
+    return (
+        <PlaygroundProvider>
+            <Playground />
+        </PlaygroundProvider>
+    );
+};

--- a/src/client/src/views/playground-test/index.ts
+++ b/src/client/src/views/playground-test/index.ts
@@ -1,0 +1,1 @@
+export * from "./PlaygroundTest";

--- a/src/client/src/views/router.tsx
+++ b/src/client/src/views/router.tsx
@@ -1,6 +1,4 @@
-import { useAuthenticated } from "../context";
 import { Authentication } from "./authentication";
-import { Dashboard } from "./dashboard";
 import { Home } from "./home";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 

--- a/src/playground/app/cleanup.py
+++ b/src/playground/app/cleanup.py
@@ -1,0 +1,27 @@
+import logging
+import subprocess
+
+def reinitialize_environment():
+    try:
+        script_path = "/playground/entrypoint.sh"
+        
+        result = subprocess.run([script_path], capture_output=True, text=True, check=True, timeout=10)
+        
+        logging.info("Script output (stdout):")
+        logging.info(result.stdout)
+        
+        if result.returncode == 0:
+            logging.info("Environment reinitialized successfully")
+        else:
+            logging.error("Script execution failed with return code %d", result.returncode)
+            logging.error(result.stderr)
+            
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Script execution failed with return code {e.returncode}")
+        logging.error(e.stderr)
+        
+    except subprocess.TimeoutExpired:
+        logging.error("Script execution timed out")
+    
+    except Exception as e:
+        logging.error(f"An error occurred while executing the script: {e}")

--- a/src/playground/app/config.py
+++ b/src/playground/app/config.py
@@ -11,3 +11,9 @@ def get_jwt_signing_key() -> str:
 
 def get_max_wait_time() -> int:
     return int(os.getenv("MAX_WAIT_TIME", 10))
+
+def get_self_destruct_enabled() -> bool:
+    return os.getenv("ENABLE_SELF_DESTRUCT", "true").lower() == "true"
+
+def get_purge_on_disconnect() -> bool:
+    return os.getenv("PURGE_DATA_ON_DISCONNECT", "false").lower() == "true"

--- a/src/playground/app/main.py
+++ b/src/playground/app/main.py
@@ -1,8 +1,12 @@
+import logging
 import os
 import time
-from .config import get_jwt_signing_key
+from .config import get_jwt_signing_key, get_purge_on_disconnect
 from .client import connect_to_server
 from .jwt import create_token
+from .cleanup import reinitialize_environment
+
+logging.basicConfig(level=logging.INFO)
 
 def initialize_session():
     pod_hostname = os.getenv("HOSTNAME")
@@ -11,24 +15,36 @@ def initialize_session():
     print(f"Hostname: {pod_hostname}")
     
     signing_key = get_jwt_signing_key()
-    token = create_token(
-        data={
-            "session_id": session_id,
-            "hostname": pod_hostname
-        }, 
-        secret=signing_key, 
-        expiration_minutes=5
-    )
     
-    # Loop until /userland/NOTICE.txt is found
     while True:
-        try:
-            with open("/userland/NOTICE.txt") as f:
-                break
-        except Exception:
-            print("Waiting for NOTICE.txt")
-            pass
+        logging.info("Generating token")
+        token = create_token(
+            data={
+                "session_id": session_id,
+                "hostname": pod_hostname
+            }, 
+            secret=signing_key, 
+            expiration_minutes=5
+        )
         
-        time.sleep(1)
-    
-    connect_to_server(token)
+        # Loop until /userland/NOTICE.txt is found
+        while True:
+            try:
+                with open("/userland/NOTICE.txt") as f:
+                    break
+            except Exception:
+                print("Waiting for NOTICE.txt")
+                pass
+            
+            time.sleep(1)
+        
+        logging.info("Connecting to server")
+        connect_to_server(token)
+        
+        if get_purge_on_disconnect():
+            logging.info("Reinitializing environment")
+            reinitialize_environment()
+            
+            logging.info("Reinitializing session")
+        else:
+            break

--- a/src/playground/entrypoint.sh
+++ b/src/playground/entrypoint.sh
@@ -1,11 +1,31 @@
 #!/bin/bash
 
+# Check if /playground/userland-scaffold exists, if not, create it
+if [ ! -d /playground/userland-scaffold ]; then
+    echo "Creating /userland-scaffold..."
+    rsync -a --exclude='/dev/*' /userland-scaffold/ /playground/userland-scaffold/
+fi
+
+# Copy the entrypoint.sh script to the shared volume
+echo "Copying entrypoint.sh to shared playground volume..."
+cp /entrypoint.sh /playground/entrypoint.sh
+chmod +x /playground/entrypoint.sh
+
+# If /userland exists, remove it
+if [ -d /userland ]; then
+    # Kill any processes belonging to 'user'
+    chroot /userland pkill -9 -u user 2>/dev/null || true
+
+    echo "Removing existing /userland files..."
+    rm -rf /userland/*
+fi
+
 # Copy the debootstrap environment into the shared volume
 echo "Copying debootstrap environment to /userland..."
-rsync -a --exclude='/dev/*' /userland-scaffold/ /userland/
-cp -r /usr/share/terminfo /userland/usr/share/
+cp -a /playground/userland-scaffold/. /userland/
+cp -a /usr/share/terminfo /userland/usr/share/
 
-# Create /dev/null
+# Create /dev/null and other device nodes
 mknod -m 666 /userland/dev/null c 1 3
 mknod -m 666 /userland/dev/zero c 1 5
 mknod -m 666 /userland/dev/random c 1 8
@@ -22,16 +42,13 @@ chroot /userland bash -c "echo 'PS1=\"\[\033[01;32m\]\u@\[\033[01;34m\]sandbox:\
 chroot /userland bash -c "echo 'cd /home/user' >> /home/user/.bashrc"
 
 # Set ownership and permissions
-chroot /userland chown -R root:root /userland
-chroot /userland chown -R user:user /userland/home/user  # Allow user to write in their home directory
-chroot /userland chmod -R 0777 /userland/home/user  # Ensure the user can write
-chroot /userland chmod -R 0755 /userland
+chroot /userland chown -R root:root /
+chroot /userland chown -R user:user /home/user  # Allow user to write in their home directory
+chroot /userland chmod -R 0777 /home/user  # Ensure the user can write
+chroot /userland chmod -R 0755 /
 
 echo "This is a sandbox environment for your Eduvize course.
 You can use this environment to run commands and programs
 without affecting your host system, and your tutor will
 be able to see what you are doing and assist you.
 " > /userland/NOTICE.txt
-
-# Keep the container running
-sleep infinity

--- a/src/playground/environment.Dockerfile
+++ b/src/playground/environment.Dockerfile
@@ -19,6 +19,7 @@ RUN chroot /userland-scaffold apt-get update && chroot /userland-scaffold apt-ge
 RUN chmod +x /userland-scaffold/bin/bash
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-# Set the entrypoint to use chroot
-ENTRYPOINT ["/entrypoint.sh"]
+# Use CMD to run the entrypoint script and then sleep indefinitely
+CMD ["/bin/bash", "-c", "/entrypoint.sh && sleep infinity"]


### PR DESCRIPTION
This PR adds changes to support the local testing of the playground environment, which originally wasn't possible as it was coupled pretty tightly with the Kubernetes API. Several modifications had to take place, in addition to introducing some new environment variables for local configuration.

## Frontend
- Added a temporary `/playground-test` route

## Backend
### Config
#### API
- Added `OVERRIDE_PLAYGROUND_SESSION_ID` to configuration through `get_playground_session_id_override` - set this to a random string and it will force the API to return it to the client for use in the playground connection initialization procedure
#### Playground Controller
- Added `ENABLE_SELF_DESTRUCT` to configuration through `get_self_destruct_enabled` - set this to `false` to prevent Kubernetes pod labeling functionality
- Added `PURGE_DATA_ON_DISCONNECT` to configuration through `get_purge_on_disconnect` - set this to `true` to re-run the `entrypoint.sh` script in order to create a fresh environment, followed by a re-connect to the websocket server for a new client
### Playground Controller
- Add `cleanup.py` module that has `reinitialize_environment` which runs the entrypoint script again to clear out the debootstrap environment and re-create it
- Create a loop in `main.py` that breaks if purge is disabled, otherwise run `cleanup.reinitialize_environment` and start over
- `Shell` now handles `terminate` more gracefully by setting a flag that will prevent emission of new events after `terminate` was called
- `client` module will attempt to connect to the websocket server multiple times before failing 
- **Bug fix**: `Shell.terminate` was improperly attempting to kill the process by calling a method on the PID. Now it will use `os` to kill it.
### Playground Service
- Session record will not be created in the database, instead an overridden session ID will be passed through
### Websocket Server
- **Bug fix**: Added deletion of both user connected and instance liveness cache keys upon disconnect. This would only really present a problem with session re-use which would only happen locally.
