### PR TITLE
Fix Image Resets after Helm Upgrade

### DIFF
--- a/.github/workflows/reusable_helm_deploy.yml
+++ b/.github/workflows/reusable_helm_deploy.yml
@@ -76,6 +76,7 @@ jobs:
           fi
 
           helm upgrade --install eduvize kubernetes/eduvize \
+            --reuse-values \
             --values ${{ inputs.VALUES_FILE_PATH }} \
             --set ingress.hostname=${{ inputs.DOMAIN_NAME }} \
             --set ${{ inputs.IMAGE_VALUES_PATH }}=${{ secrets.REGISTRY_NAME }}/$IMAGE_REPO \


### PR DESCRIPTION
This PR adds a small change to the reusable helm deployment workflow to include `--reuse-flags` so that overriden values, namely the image for the deployed resource, is persisted during the next upgrade.

The issue here was that if you, for example, deployed the frontend codebase it would override the image tag with the commit SHA, but also reset all other deployments to the `latest` tag (set in values.yaml)