### PR TITLE
Tweak Image Tags in Deployment Pipelines

### DIFF
--- a/.github/workflows/build_deploy_api.yml
+++ b/.github/workflows/build_deploy_api.yml
@@ -25,8 +25,6 @@ jobs:
     name: Deploy API
     uses: ./.github/workflows/reusable_helm_deploy.yml
     with:
-      IMAGE_NAME: "api"
-      IMAGE_VALUES_PATH: "api.image"
       DEPLOYMENT_NAME: "eduvize-api"
       DOMAIN_NAME: "eduvize.dev"
     secrets: inherit

--- a/.github/workflows/build_deploy_client.yml
+++ b/.github/workflows/build_deploy_client.yml
@@ -27,8 +27,6 @@ jobs:
     name: Deploy Client
     uses: ./.github/workflows/reusable_helm_deploy.yml
     with:
-      IMAGE_NAME: "app"
-      IMAGE_VALUES_PATH: "frontend.image"
       DEPLOYMENT_NAME: "eduvize"
       DOMAIN_NAME: "eduvize.dev"
     secrets: inherit

--- a/.github/workflows/build_deploy_course_generator.yml
+++ b/.github/workflows/build_deploy_course_generator.yml
@@ -24,8 +24,6 @@ jobs:
     name: Deploy Course Generator
     uses: ./.github/workflows/reusable_helm_deploy.yml
     with:
-      IMAGE_NAME: "course-generator"
-      IMAGE_VALUES_PATH: "course_generator.image"
       DEPLOYMENT_NAME: "eduvize-course-generator"
       DOMAIN_NAME: "eduvize.dev"
     secrets: inherit

--- a/.github/workflows/build_deploy_playground_orchestrator.yml
+++ b/.github/workflows/build_deploy_playground_orchestrator.yml
@@ -23,8 +23,6 @@ jobs:
     name: Deploy Playground Orchestrator
     uses: ./.github/workflows/reusable_helm_deploy.yml
     with:
-      IMAGE_NAME: "playground-orchestrator"
-      IMAGE_VALUES_PATH: "playground.orchestratorImage"
       DEPLOYMENT_NAME: "eduvize-playground-orchestrator"
       DOMAIN_NAME: "eduvize.dev"
     secrets: inherit

--- a/.github/workflows/reusable_build_push.yml
+++ b/.github/workflows/reusable_build_push.yml
@@ -7,6 +7,11 @@ on:
         type: string
         description: "The name of the image"
         required: true
+      IMAGE_TAG:
+        type: string
+        description: "The tag of the image (environment based)"
+        required: false
+        default: "latest"
       DOCKERFILE:
         type: string
         description: "Path to the Dockerfile"
@@ -84,7 +89,7 @@ jobs:
           if [ ${{ inputs.RUN_TESTS }} = true ]; then
             TAG="test-${{ github.sha}}"
           else
-            TAG="${{ github.sha }}"
+            TAG="${{ inputs.IMAGE_TAG }}"
           fi
 
           if [ -n "${{ inputs.REGISTRY_PREFIX }}" ]; then

--- a/.github/workflows/reusable_helm_deploy.yml
+++ b/.github/workflows/reusable_helm_deploy.yml
@@ -22,14 +22,11 @@ on:
         description: "Path to the Helm values file"
         required: false
         default: "kubernetes/eduvize/values.yaml"
-      IMAGE_VALUES_PATH:
+      IMAGE_TAG:
         type: string
-        description: "Path to the image in the Helm values file"
-        required: true
-      IMAGE_NAME:
-        type: string
-        description: "The name of the image"
-        required: true
+        description: "The tag of the image (environment based)"
+        required: false
+        default: "latest"
       REGISTRY_PREFIX:
         type: string
         description: "The registry prefix"
@@ -69,17 +66,14 @@ jobs:
 
       - name: Helm Upgrade
         run: |
-          if [ -n "${{ inputs.REGISTRY_PREFIX }}" ]; then
-            IMAGE_REPO="${{ inputs.REGISTRY_PREFIX }}/${{ inputs.IMAGE_NAME }}:${{ github.sha }}"
-          else
-            IMAGE_REPO="${{ inputs.IMAGE_NAME }}:${{ github.sha }}"
-          fi
-
           helm upgrade --install eduvize kubernetes/eduvize \
-            --reuse-values \
             --values ${{ inputs.VALUES_FILE_PATH }} \
             --set ingress.hostname=${{ inputs.DOMAIN_NAME }} \
-            --set ${{ inputs.IMAGE_VALUES_PATH }}=${{ secrets.REGISTRY_NAME }}/$IMAGE_REPO \
+            --set frontend.image=${{ secrets.REGISTRY_NAME }}/${{ inputs.REGISTRY_PREFIX }}/app:${{ inputs.IMAGE_TAG }} \
+            --set api.image=${{ secrets.REGISTRY_NAME }}/${{ inputs.REGISTRY_PREFIX }}/api:${{ inputs.IMAGE_TAG }} \
+            --set course_generator.image=${{ secrets.REGISTRY_NAME }}/${{ inputs.REGISTRY_PREFIX }}/course-generator:${{ inputs.IMAGE_TAG }} \
+            --set playground.controllerImage=${{ secrets.REGISTRY_NAME }}/${{ inputs.REGISTRY_PREFIX }}/playground-controller:${{ inputs.IMAGE_TAG }} \
+            --set playground.orchestratorImage=${{ secrets.REGISTRY_NAME }}/${{ inputs.REGISTRY_PREFIX }}/playground-orchestrator:${{ inputs.IMAGE_TAG }} \
             --namespace ${{ inputs.RELEASE_NAMESPACE }} \
             --debug
 


### PR DESCRIPTION
This PR makes a tag-related change for the deployment pipelines, essentially reverting back to using `latest`. An issue was cropping up where the helm upgrade would effectively overwrite the image tags for all other non-deployed services back to `latest`, which is not ideal and would lead to differently-versioned code being released to production.

For the interim, `latest` will continue to be used. A change has been added to the reusable templates for specifying a tag, which in the future can be used to set an environment-specific tag if we decide to stand up a development or QA environment.